### PR TITLE
add description and tags

### DIFF
--- a/plugins/es_optimizer/api.py
+++ b/plugins/es_optimizer/api.py
@@ -24,7 +24,7 @@ from .plugin import EsOptimizer
 PLUGIN_BLP = SecurityBlueprint( #SecurityBlueprint for eventual JWT support
     EsOptimizer.instance.identifier,  # blueprint name
     __name__,  # module import name!
-    description="An optimizer using an evolutionary strategy.",
+    description="ES-Optimizer plugin API.",
 )
 
 

--- a/plugins/es_optimizer/plugin.py
+++ b/plugins/es_optimizer/plugin.py
@@ -17,6 +17,8 @@ class EsOptimizer(QHAnaPluginBase):
 
     name = _plugin_name
     version = __version__
+    description = "An optimizer using an evolutionary strategy."
+    tags = ["ES", "optimizer"]
 
     def __init__(self, app: Optional[Flask]) -> None:
         super().__init__(app)


### PR DESCRIPTION
This plugin crashed the most recent version of the plugin runner.
It now requires a description as property of the plugin object as well as tags.